### PR TITLE
Modify the axis angle parameter in the OAT protocol

### DIFF
--- a/run_OAT.py
+++ b/run_OAT.py
@@ -63,7 +63,7 @@ def simulate_OAT(
 
     # un-rotate about a chosen axis
     time_3 = -params[2] * np.pi
-    rot_axis_angle = params[3] * np.pi / 2
+    rot_axis_angle = params[3] * 2 * np.pi
     hamiltonian_3 = np.cos(rot_axis_angle) * collective_Sx + np.sin(rot_axis_angle) * collective_Sy
     state_3 = evolve_state(state_2, time_3, hamiltonian_3)
 


### PR DESCRIPTION
After thinking about the symmetries of our OAT protocol more deeply (see the [Overleaf](https://www.overleaf.com/project/6345ad8bae208db479d20d7e)), I now think that it makes most sense to define our last parameter as a multiple of `2 pi` instead of `pi / 2`.  I still think it makes most sense to make all other parameters multiples of `pi`.

Altogether, the domain for `params` is (probably***) `[0,1/2]^3 x [0,1)`.  At zero dissipation, points outside this region can be mapped to points within this region using symmetries of the OAT protocol.  At nonzero dissipation, going outside this region requires strictly longer experimental runtimes, which should thereby result in worse QFI.

*** I say "probably" because I only have a physical argument for why the second parameter should be in `[0,1/2]` instead of `[0,1)`; I have not yet figured out a mathematical argument or derivation.  Either way, this point does not affect how I think the parameters of the protocol should be defined.