### PR TITLE
Add symmetry tests

### DIFF
--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -362,7 +362,7 @@ if __name__ == "__main__":
             print(f"d(final_state/d(params[{pp}]):")
             print(jacobian[:, :, pp])
 
-    # simulate the OAT potocol
+    # simulate the OAT protocol
     final_state = simulate_OAT(args.params, args.num_qubits, dissipation_rates=args.dissipation)
 
     # compute collective Pauli operators

--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -108,10 +108,10 @@ def enable_axial_symmetry(simulate_func: Callable[..., np.ndarray]) -> Callable[
                         "\nTry passing the argument `axial_symmetry=False` to the simulation method."
                     )
 
-            # Check that there are only four parameters (initial rotation angle, entangling time, final rotation angle + axis).
-            # Insert an initial rotation axis of 0 into the first location of the parameter array (at index 1).
-            assert len(params) == 4, "Spin sensing protocols with axial symmetry accept four parameters."
-            params = np.insert(np.array(params), 1, 0.0)
+            # If there are only four parameters, (initial_rotation_angle, entangling_time, final_rotation_angle, final_rotation_axis),
+            # inject an initial_rotation_axis of 0 into the first location of the parameter array (at index 1).
+            if len(params) == 4:
+                params = np.insert(np.array(params), 1, 0.0)
 
         return simulate_func(params, *args, **kwargs)
 

--- a/qfi_opt/spin_models_test.py
+++ b/qfi_opt/spin_models_test.py
@@ -33,6 +33,10 @@ class Transformation:
         return new_state
 
 
+Params = tuple[float, float, float, float, float]
+Symmetry = Callable[[float, float, float, float, float], tuple[Params, Transformation]]
+
+
 def get_random_hamiltonian(dim: int) -> np.ndarray:
     """Construct a random Hamiltonian on a system of with the given dimension."""
     ham = numpy.random.random((dim, dim)) + 1j * numpy.random.random((dim, dim))
@@ -50,10 +54,6 @@ def rot_z_mat(num_qubits: int, angle: float) -> np.ndarray:
     _, _, collective_Sz = spin_models.collective_spin_ops(num_qubits)
     phase_vec = np.exp(-1j * angle * collective_Sz.diagonal())
     return phase_vec[:, np.newaxis] * np.conj(phase_vec)
-
-
-Params = tuple[float, float, float, float, float]
-Symmetry = Callable[[float, float, float, float, float], tuple[Params, Transformation]]
 
 
 def get_symmetries_common() -> Sequence[Symmetry]:

--- a/qfi_opt/spin_models_test.py
+++ b/qfi_opt/spin_models_test.py
@@ -106,7 +106,7 @@ def get_symmetries_Z2_Z2() -> List[Callable[..., tuple[Params, Transformation]]]
     """Generate a list of symmetries for protocol with Z_2 x Z_2 symmetry."""
 
     def reflect_z(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
-        return (t_1, a_1 + 1, t_ent, t_2, a_2 + 1), Transformation()
+        return (t_1, a_1 + 0.5, t_ent, t_2, a_2 + 0.5), Transformation(final_rz=np.pi)
 
     def reflect_x(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
         final_rz = 4 * np.pi * a_2
@@ -121,7 +121,6 @@ def get_symmetries_Z2_Z2() -> List[Callable[..., tuple[Params, Transformation]]]
 def test_symmetries(atol: float = 1e-6) -> None:
     """Test the symmetry transformations that we used to cut down the domain of the parameters for the OAT protocol."""
     for _ in range(5):  # test several random instances
-        print(_)
         params = list(numpy.random.random(5))
         coupling_op = get_random_hamiltonian(4)
         coupling_exponent = numpy.random.random() * 3

--- a/qfi_opt/spin_models_test.py
+++ b/qfi_opt/spin_models_test.py
@@ -1,6 +1,6 @@
 import dataclasses
 import functools
-from typing import Callable, Sequence, Optional
+from typing import Callable, Optional, Sequence
 
 import jax.numpy as np
 import numpy

--- a/qfi_opt/spin_models_test.py
+++ b/qfi_opt/spin_models_test.py
@@ -104,17 +104,18 @@ def get_symmetries_U1_Z2() -> Sequence[Symmetry]:
 def get_symmetries_Z2_Z2() -> Sequence[Symmetry]:
     """Generate a list of symmetries for protocol with an axial Z_2 and transverse Z_2 symmetry."""
 
-    def reflect_z(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
-        return (t_1, a_1 + 0.5, t_ent, t_2, a_2 + 0.5), Transformation(final_rz=np.pi)
+    def rot_z(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
+        final_rz = -np.pi / 2
+        return (t_1, a_1 + 0.25, -t_ent, t_2, a_2 + 0.25), Transformation(final_rz=final_rz)
 
-    def reflect_x(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
+    def pi_x(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
         final_rz = 4 * np.pi * a_2
         return (t_1 + 1, -a_1, -t_ent, t_2 + 1, -a_2), Transformation(final_rz=final_rz)
 
     def conjugate(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
         return (-t_1, -a_1, t_ent, -t_2, -a_2), Transformation(conjugate=True)
 
-    return [reflect_z, reflect_x, conjugate]
+    return [rot_z, pi_x, conjugate]
 
 
 def get_symmetries_OAT(even_qubit_number: bool) -> Sequence[Symmetry]:

--- a/qfi_opt/spin_models_test.py
+++ b/qfi_opt/spin_models_test.py
@@ -88,9 +88,10 @@ def get_symmetries_common() -> Sequence[Symmetry]:
 def get_symmetries_U1_Z2() -> Sequence[Symmetry]:
     """Generate a list of symmetries for protocol with an axial U(1) and transverse Z_2 symmetry."""
 
-    def eliminate_axis(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
-        final_rz = 2 * np.pi * a_1
-        return (t_1, 0, t_ent, t_2, a_2 - a_1), Transformation(final_rz=final_rz)
+    def shift_axes(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
+        axis_shift = numpy.random.random()
+        final_rz = 2 * np.pi * axis_shift
+        return (t_1, a_1 - axis_shift, t_ent, t_2, a_2 - axis_shift), Transformation(final_rz=final_rz)
 
     def shift_1(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
         return (t_1 + 1, a_1, t_ent, t_2, 2 * a_1 - a_2), Transformation(flip_xy=a_1)
@@ -98,7 +99,7 @@ def get_symmetries_U1_Z2() -> Sequence[Symmetry]:
     def conjugate(t_1: float, a_1: float, t_ent: float, t_2: float, a_2: float) -> tuple[Params, Transformation]:
         return (-t_1, -a_1, -t_ent, -t_2, -a_2), Transformation(conjugate=True)
 
-    return [eliminate_axis, shift_1, conjugate]
+    return [shift_axes, shift_1, conjugate]
 
 
 def get_symmetries_Z2_Z2() -> Sequence[Symmetry]:

--- a/qfi_opt/spin_models_test.py
+++ b/qfi_opt/spin_models_test.py
@@ -10,7 +10,7 @@ from qfi_opt import spin_models
 
 @dataclasses.dataclass(kw_only=True)
 class Transformation:
-    """An object representing a sequence of transformations of a quantum state."""
+    """An object representing a sequence of transformations to apply to a quantum state."""
 
     final_rz: float = 0
     flip_xy: Optional[float] = None
@@ -33,7 +33,14 @@ class Transformation:
         return new_state
 
 
+# Type signature for the parameters of a sensing protocol.
 Params = tuple[float, float, float, float, float]
+
+# A symmetry `S` maps a set of parameters `p_old` to a set of parameters `p_new` together with a transformation `T`, i.e., `S: p_old --> (p_new, T)`.
+# The symmetry is such that the following two procedures yield the same state:
+# - Running a sensing protocol with parameters `p_old`.
+# - Running the same sensing protocol with parameters `p_new`, and applying the transformation `T` to the resulting state.
+# In other words, if `rho(p)` is the state returned by a sensing protocol with parameters `p`, then `rho(p_old) = T(rho(p_new))`.
 Symmetry = Callable[[float, float, float, float, float], tuple[Params, Transformation]]
 
 


### PR DESCRIPTION
Add tests of all symmetries used to restrict the parameter domain of the OAT and TAT protocols (see [notes](https://www.overleaf.com/project/6345ad8bae208db479d20d7e)).