### PR TITLE
Allow using both JAX and Scipy

### DIFF
--- a/qfi_opt/__init__.py
+++ b/qfi_opt/__init__.py
@@ -1,8 +1,9 @@
-from . import dissipation, examples, ode_jax, plot, spin_models
+from . import dissipation_jax, dissipation_numpy, examples, ode_jax, plot, spin_models
 
 __all__ = [
     "__version__",
-    "dissipation",
+    "dissipation_jax",
+    "dissipation_numpy",
     "examples",
     "ode_jax",
     "plot",

--- a/qfi_opt/examples/calculate_qfi.py
+++ b/qfi_opt/examples/calculate_qfi.py
@@ -23,7 +23,7 @@ def compute_QFI(eigvals: np.ndarray, eigvecs: np.ndarray, G: np.ndarray, tol: fl
     # There should never be negative eigenvalues, so their magnitude gives an
     # empirical estimate of the numerical accuracy of the eigendecomposition.
     # We discard any QFI terms denominators within an order of magnitude of
-    # this value. 
+    # this value.
     tol = max(tol, -etol_scale * np.min(eigvals))
 
     # Compute QFI

--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -2,16 +2,28 @@
 import argparse
 import functools
 import itertools
+import os
 import sys
 from typing import Any, Callable, Optional, Sequence
 
-import jax
-import jax.numpy as np
-
 import qfi_opt
-from qfi_opt.dissipation import Dissipator
 
-jax.config.update("jax_enable_x64", True)
+DISABLE_JAX = bool(os.getenv("DISABLE_JAX"))
+
+if not DISABLE_JAX:
+    import jax
+    import jax.numpy as np
+
+    from qfi_opt.dissipation_jax import Dissipator
+
+    jax.config.update("jax_enable_x64", True)
+
+else:
+    import numpy as np  # type: ignore[no-redef]
+    import scipy
+
+    from qfi_opt.dissipation_numpy import Dissipator  # type: ignore[assignment]
+
 
 COMPLEX_TYPE = np.complex128
 DEFAULT_DISSIPATION_FORMAT = "XYZ"
@@ -241,8 +253,10 @@ def evolve_state(
     time: float | np.ndarray,
     hamiltonian: np.ndarray,
     dissipator: Optional[Dissipator] = None,
+    *,
     rtol: float = 1e-8,
     atol: float = 1e-8,
+    disable_jax: bool = DISABLE_JAX,
 ) -> np.ndarray:
     """
     Time-evolve a given initial density operator for a given amount of time under the given Hamiltonian and (optionally) Dissipator.
@@ -257,11 +271,27 @@ def evolve_state(
 
     times = np.linspace(0.0, time, 2)
     time_deriv = get_time_deriv(hamiltonian, dissipator)
-    result = qfi_opt.ode_jax.odeint(time_deriv, density_op, times, rtol=rtol, atol=atol)
-    return result[-1]
+
+    if not DISABLE_JAX:
+        result = qfi_opt.ode_jax.odeint(time_deriv, density_op, times, rtol=rtol, atol=atol)
+        return result[-1]
+
+    def scipy_time_deriv(time: float, density_op: np.ndarray) -> np.ndarray:
+        density_op.shape = (hamiltonian.shape[0],) * 2  # type: ignore[misc]
+        output = time_deriv(density_op, time)
+        density_op.shape = (-1,)  # type: ignore[misc]
+        return output.ravel()
+
+    result = scipy.integrate.solve_ivp(scipy_time_deriv, times, density_op.ravel(), rtol=rtol, atol=atol)
+    return result.y[:, -1].reshape(density_op.shape)
 
 
-def get_time_deriv(hamiltonian: np.ndarray, dissipator: Optional[Dissipator] = None) -> Callable[[np.ndarray, float], np.ndarray]:
+def get_time_deriv(
+    hamiltonian: np.ndarray,
+    dissipator: Optional[Dissipator] = None,
+    *,
+    disable_jax: bool = DISABLE_JAX,
+) -> Callable[[np.ndarray, float], np.ndarray]:
     """Construct a time derivative function that maps (state, time) --> d(state)/d(time)."""
 
     # construct the time derivative from coherent evolution
@@ -280,7 +310,11 @@ def get_time_deriv(hamiltonian: np.ndarray, dissipator: Optional[Dissipator] = N
 
     if not dissipator:
         return coherent_time_deriv
-    return lambda state, time: coherent_time_deriv(state, time) + dissipator @ state
+
+    def dissipative_time_deriv(density_op: np.ndarray, time: float) -> np.ndarray:
+        return coherent_time_deriv(density_op, time) + dissipator @ density_op
+
+    return dissipative_time_deriv
 
 
 @functools.cache


### PR DESCRIPTION
For now the stopgap is to check for an environment variable DISABLE_JAX.  If defined (and nonempty), these codes will use scipy.  You can set it with `export DISABLE_JAX=1` in the command line, and un-set it with `export DISABLE_JAX=`.


I'll add a manual calculation Jacobian as well soon.