### PR TITLE
Making solver an argument is problematic when DISABLE_DIFFRAX is True

### DIFF
--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -255,7 +255,6 @@ def evolve_state(
     rtol: float = 1e-8,
     atol: float = 1e-8,
     disable_diffrax: bool = DISABLE_DIFFRAX,
-    solver: diffrax.AbstractSolver = diffrax.Tsit5(),  # try also diffrax.Dopri8()
     **diffrax_kwargs: object,
 ) -> np.ndarray:
     """
@@ -271,6 +270,7 @@ def evolve_state(
 
     if not DISABLE_DIFFRAX:
 
+        solver = diffrax.AbstractSolver = diffrax.Tsit5()  # try also diffrax.Dopri8()
         # set initial time step size, if necessary
         if "dt0" not in diffrax_kwargs:
             diffrax_kwargs["dt0"] = 0.002


### PR DESCRIPTION
Fixes this bug
```
export DISABLE_DIFFRAX=True; python qfi_opt/spin_models.py --jacobian --num_qubits 2
Traceback (most recent call last):
  File "/Users/snarayan/soft/QFI-Opt/qfi_opt/spin_models.py", line 11, in <module>
    from qfi_opt.dissipation import Dissipator
  File "/Users/snarayan/soft/QFI-Opt/qfi_opt/__init__.py", line 1, in <module>
    from . import dissipation, examples, plot, spin_models
  File "/Users/snarayan/soft/QFI-Opt/qfi_opt/plot.py", line 10, in <module>
    from qfi_opt import spin_models
  File "/Users/snarayan/soft/QFI-Opt/qfi_opt/spin_models.py", line 259, in <module>
    solver: diffrax.AbstractSolver = diffrax.Tsit5(),  # try also diffrax.Dopri8()
NameError: name 'diffrax' is not defined
```