### PR TITLE
Change default coulping exponent

### DIFF
--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -186,7 +186,7 @@ def simulate_spin_chain(
     params: Sequence[float] | np.ndarray,
     num_qubits: int,
     coupling_op: np.ndarray,
-    coupling_exponent: float = 0.0,
+    coupling_exponent: float = 1.0,
     *,
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
@@ -208,7 +208,7 @@ def simulate_spin_chain(
 def simulate_ising_chain(
     params: Sequence[float] | np.ndarray,
     num_qubits: int,
-    coupling_exponent: float = 0.0,
+    coupling_exponent: float = 1.0,
     *,
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
@@ -228,7 +228,7 @@ def simulate_ising_chain(
 def simulate_XX_chain(
     params: Sequence[float] | np.ndarray,
     num_qubits: int,
-    coupling_exponent: float = 0.0,
+    coupling_exponent: float = 1.0,
     *,
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
@@ -247,7 +247,7 @@ def simulate_XX_chain(
 def simulate_local_TAT_chain(
     params: Sequence[float] | np.ndarray,
     num_qubits: int,
-    coupling_exponent: float = 0.0,
+    coupling_exponent: float = 1.0,
     *,
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,


### PR DESCRIPTION
... to avoid accidentally bumping into features of the `*_chain` models that actually only occur on a measure-0 subset of model parameters.