### PR TITLE
Support **kwargs in forward mode so that a dissipation rate can be

### DIFF
--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -404,7 +404,7 @@ def get_jacobian_func(simulate_func: Callable) -> Callable:
 
         def get_jacobian(params: Sequence[float], *args: object, **kwargs: object) -> np.ndarray:
             param_array = np.array(params)
-            call_func = lambda params: simulate_func(params, *args)
+            call_func = lambda params: simulate_func(params, *args,  **kwargs)
             result = []
             for ii in range(len(param_array)):
                 seed = np.zeros(len(param_array), dtype=np.float64)


### PR DESCRIPTION
specified. This is not supported in reverse mode.