### PR TITLE
AD with fewer function calls

### DIFF
--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -13,6 +13,7 @@ from qfi_opt.dissipation import Dissipator
 
 USE_DIFFRAX = bool(os.getenv("USE_DIFFRAX"))
 FORWARD_MODE = not bool(os.getenv("REVERSE_MODE"))
+GET_ALL = bool(os.getenv("GET_ALL"))
 
 if USE_DIFFRAX:
     import jax
@@ -295,7 +296,7 @@ def evolve_state(
 
         term = diffrax.ODETerm(_time_deriv)
         solver = solver or diffrax.Tsit5()  # try also diffrax.Dopri8()
-        solver_args = dict(t0=0.0, t1=time, y0=density_op, args=(hamiltonian,))
+        solver_args = dict(t0=0.0, t1=time.real, y0=density_op, args=(hamiltonian,))
         if FORWARD_MODE:
             diffrax_kwargs["max_steps"] = diffrax_kwargs.get("max_steps", None)
             solver_args |= dict(adjoint=diffrax.DirectAdjoint())
@@ -402,9 +403,20 @@ def get_jacobian_func(simulate_func: Callable) -> Callable:
     if USE_DIFFRAX and FORWARD_MODE:
         # forward-mode automatic differentiation
 
+        if GET_ALL:
+
+            def get_jacobian(params: Sequence[float], *args: object, **kwargs: object) -> np.ndarray:
+                param_array = np.array(params)
+                call_func = lambda params: simulate_func(params, *args, **kwargs)
+                jacfwd_fun = jax.jacfwd(call_func, argnums=0, holomorphic=True)
+                jacobian = jacfwd_fun(np.array(param_array, dtype=COMPLEX_TYPE))
+                return jacobian
+
+            return get_jacobian
+
         def get_jacobian(params: Sequence[float], *args: object, **kwargs: object) -> np.ndarray:
             param_array = np.array(params)
-            call_func = lambda params: simulate_func(params, *args,  **kwargs)
+            call_func = lambda params: simulate_func(params, *args, **kwargs)
             result = []
             for ii in range(len(param_array)):
                 seed = np.zeros(len(param_array), dtype=np.float64)


### PR DESCRIPTION
Use `jax.jacfwd` to extract the forward-mode AD in fewer function calls.  Credit to @sriharikrishna for method; I'm just doing a bit of cleanup of his codes in this PR.