### PR TITLE
place TAT-based models on an equal footing with OAT-based models

### DIFF
--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -214,7 +214,7 @@ def simulate_ising_chain(
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
 ) -> np.ndarray:
-    coupling_op = np.kron(PAULI_Z, PAULI_Z) / 4
+    coupling_op = np.kron(PAULI_Z, PAULI_Z) / 2
     return simulate_spin_chain(
         params,
         num_qubits,
@@ -234,7 +234,7 @@ def simulate_XX_chain(
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
 ) -> np.ndarray:
-    coupling_op = (np.kron(PAULI_X, PAULI_X) + np.kron(PAULI_Y, PAULI_Y)) / 4
+    coupling_op = (np.kron(PAULI_X, PAULI_X) + np.kron(PAULI_Y, PAULI_Y)) / 2
     return simulate_spin_chain(
         params,
         num_qubits,
@@ -253,7 +253,7 @@ def simulate_local_TAT_chain(
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
 ) -> np.ndarray:
-    coupling_op = (np.kron(PAULI_X, PAULI_Y) + np.kron(PAULI_Y, PAULI_X)) / 8
+    coupling_op = (np.kron(PAULI_X, PAULI_Y) + np.kron(PAULI_Y, PAULI_X)) / 4
     return simulate_spin_chain(
         params,
         num_qubits,

--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -214,7 +214,7 @@ def simulate_ising_chain(
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
 ) -> np.ndarray:
-    coupling_op = np.kron(PAULI_Z, PAULI_Z) / 2
+    coupling_op = np.kron(PAULI_Z, PAULI_Z) / 4
     return simulate_spin_chain(
         params,
         num_qubits,
@@ -234,7 +234,7 @@ def simulate_XX_chain(
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
 ) -> np.ndarray:
-    coupling_op = (np.kron(PAULI_X, PAULI_X) + np.kron(PAULI_Y, PAULI_Y)) / 2 / 4
+    coupling_op = (np.kron(PAULI_X, PAULI_X) + np.kron(PAULI_Y, PAULI_Y)) / 4
     return simulate_spin_chain(
         params,
         num_qubits,
@@ -253,7 +253,7 @@ def simulate_local_TAT_chain(
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
 ) -> np.ndarray:
-    coupling_op = (np.kron(PAULI_X, PAULI_Y) + np.kron(PAULI_Y, PAULI_X)) / 2
+    coupling_op = (np.kron(PAULI_X, PAULI_Y) + np.kron(PAULI_Y, PAULI_X)) / 8
     return simulate_spin_chain(
         params,
         num_qubits,

--- a/qfi_opt/spin_models.py
+++ b/qfi_opt/spin_models.py
@@ -174,7 +174,7 @@ def simulate_TAT(
 ) -> np.ndarray:
     """Simulate a two-axis twisting (TAT) protocol."""
     collective_Sx, collective_Sy, _ = collective_spin_ops(num_qubits)
-    hamiltonian = (collective_Sx @ collective_Sy + collective_Sy @ collective_Sx) / num_qubits
+    hamiltonian = (collective_Sx @ collective_Sy + collective_Sy @ collective_Sx) / (2 * num_qubits)
     return simulate_sensing_protocol(
         params,
         hamiltonian,
@@ -234,7 +234,7 @@ def simulate_XX_chain(
     dissipation_rates: float | tuple[float, float, float] = 0.0,
     dissipation_format: str = DEFAULT_DISSIPATION_FORMAT,
 ) -> np.ndarray:
-    coupling_op = (np.kron(PAULI_X, PAULI_X) + np.kron(PAULI_Y, PAULI_Y)) / 2
+    coupling_op = (np.kron(PAULI_X, PAULI_X) + np.kron(PAULI_Y, PAULI_Y)) / 2 / 4
     return simulate_spin_chain(
         params,
         num_qubits,


### PR DESCRIPTION
refactor TAT by 1/2; refactor fTAT by 1/4 so that it reverts to the refactored TAT in the case of coupling_exponent = 0